### PR TITLE
Switch to stable

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           default: true
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
       -
         uses: actions-rs/cargo@v1
         with:
@@ -76,7 +76,7 @@ jobs:
         with:
           default: true
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
       -
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           default: true
       - uses: actions-rs/cargo@v1
         with:
@@ -47,7 +47,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           default: true
       - uses: actions-rs/cargo@v1
         with:
@@ -67,7 +67,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           default: true
           components: 'rustfmt, clippy'
       - uses: actions-rs/cargo@v1
@@ -89,7 +89,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           default: true
       - uses: actions/checkout@v2
         with:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,0 @@
-format_code_in_doc_comments = true
-format_strings = true
-reorder_impl_items = true
-merge_imports = true
-imports_layout = "HorizontalVertical"
-


### PR DESCRIPTION
Switch to the stable branch. Nightly has a bug and there's not really a
good reason we're using it.
