### PR TITLE
fix: Remove magic

### DIFF
--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -67,6 +67,7 @@ jobs:
       - shell: bash
         run: |
           brew update-reset
+          brew test-bot --cleanup --only-cleanup-before
           brew tap purplebooth/repo
           cp formula/formula.rb "$(brew --repo)/Library/Taps/purplebooth/homebrew-repo/Formula/$REPOSITORY_NAME.rb"
           brew install "purplebooth/repo/$REPOSITORY_NAME"


### PR DESCRIPTION
This removes a variable that's used to magically autodetect if we're on
CI
